### PR TITLE
Solve zero division bug and test solution for calculateRisk

### DIFF
--- a/react-time-track/src/tests/utils/calculateRisk.test.js
+++ b/react-time-track/src/tests/utils/calculateRisk.test.js
@@ -48,7 +48,8 @@ const weeklyData = [
       estimated_cost: "1000000",
       real_cost: "10000"
     }
-  ]
+  ],
+  []
 ];
 
 const weeklyExpected = [
@@ -67,4 +68,8 @@ test("Test return progress function 2", () => {
 
 test("Test return progress function 3", () => {
   expect(calculateRisk(weeklyData[2])).toEqual(weeklyExpected[2]);
+});
+
+test("Test return progress function 4", () => {
+  expect(calculateRisk(weeklyData[3])).toEqual(weeklyExpected[2]);
 });

--- a/react-time-track/src/utils/calculateRisk.js
+++ b/react-time-track/src/utils/calculateRisk.js
@@ -6,7 +6,6 @@
 
 function resumeWeekly(weeklyData) {
   const projectsCosts = weeklyData.reduce((accum, data) => {
-    if (data === 0) return void 0;
     if (accum.length === 0) {
       accum.push(data.estimated_cost);
       accum.push(data.real_cost);
@@ -34,7 +33,7 @@ function calculateRisk(weekly) {
   let riskValue = [];
   let weekData = [];
 
-  if (weekly.length === 0) weekData = [0, 0];
+  if (weekly.length === 0) weekData = [1, 0];
   else weekData = resumeWeekly(weekly);
 
   const colorizer = weekData[1] / weekData[0];


### PR DESCRIPTION
Previously, if weekly_project_reports was empty, a previous calculus will return an array with values [0,0] (first position is accumulated estimated_cost, second is accumulated real_cost) which produced a zero division error ( 0 / 0 ).

Error was corrected and the code was tested for an empty array.

close #61 